### PR TITLE
Remove voice over enabled checks

### DIFF
--- a/OmniAX/Sources/Core/AX.swift
+++ b/OmniAX/Sources/Core/AX.swift
@@ -237,9 +237,6 @@ public final class AX: NSObject {
     ///   - excludeHidden: Hidden UIView elements are excluded from summary by default
     ///   - frame: If non-nil, the accessibilyFrame of the parent element is set to this value. Will need to handle scrolling manually
     public static func summarize(elements: [NSObject?], in element: NSObject?, inheritTraits: Bool = true, excludeHidden: Bool = true, frame: CGRect? = nil) {
-        guard voiceOverEnabled else {
-            return
-        }
         guard let element = element else {
             return
         }

--- a/OmniAX/Sources/Core/AbbreviationTransformer.swift
+++ b/OmniAX/Sources/Core/AbbreviationTransformer.swift
@@ -46,7 +46,7 @@ public struct Transformer: AbbrevationTransformer {
     /// Uses regular expression to replace occurrences of known abbrevations into their corresponding full words
     /// Iterates through and performs all generalTransform functions passed in AX configuration
     public func unabbreviate(string: String?) -> String? {
-        guard AX.voiceOverEnabled, var correctedString = string else {
+        guard var correctedString = string else {
             return string
         }
 


### PR DESCRIPTION
Looks like we skip summarize and unabbreviate calls if voiceover isn't running. Can we remove both these checks and still continue to work correctly?